### PR TITLE
Fix IOError when Pokemon subdirectory doesn't exist

### DIFF
--- a/src/getpkm.py
+++ b/src/getpkm.py
@@ -17,6 +17,7 @@ from binascii import hexlify
 from array import array
 from namegen import namegen
 from stats import statread
+from os import mkdir
 import os.path, subprocess, platform
 
 def makepkm(bytes):
@@ -44,6 +45,8 @@ def makepkm(bytes):
 
 def save(path, data):
     saved = False
+    if not os.path.isdir('Pokemon'):
+        mkdir('Pokemon')
 
     while not saved:
         fullpath = os.path.normpath('Pokemon' + os.sep + path)


### PR DESCRIPTION
On Windows 7 with Python 2.7.18 I got an `IOError: [Errno 2] No such file or directory: 'Pokemon\\Whatever.pkm'` when receiving a Pokemon for the first time because the Pokemon subdirectory did not exist. I added code to create the directory if it did not exist, which fixed the error.